### PR TITLE
Small spelling and grammatical changes to docs.

### DIFF
--- a/doc/source/overview/cells.rst
+++ b/doc/source/overview/cells.rst
@@ -233,7 +233,7 @@ Every Cell gets a constructor that has the following python signature::
   This may be abused for **documentation**, **prototyping**, and **GUI** applications.
   
 
-The first optional non-keyword argment is the cell's instance name. The instance
+The first optional non-keyword argument is the cell's instance name. The instance
 name is useful for debug and graph display purposes.  Each parameter that was
 declared by the cell may be initialized as a keyword argument.  Other advanced keyword arguments
 may exist, that are defined by ecto, such as :ref:`strands`.
@@ -256,7 +256,7 @@ Configuration and Processing
   manipulate your tendrils from python... Oh and you get python bindings
   for free for all the basic types.
   
-So even thought we have a shell of cell, we can still manipulate its :ref:`tendrils`.
+So even though we only have a shell of a cell, we can still manipulate its :ref:`tendrils`.
 Lets set the input tendril, called `message`, to a custom string. Then we'll call
 process.
 

--- a/doc/source/overview/modules.rst
+++ b/doc/source/overview/modules.rst
@@ -47,7 +47,7 @@ And every other cpp file will contain typically a single cell, exported:
   ECTO_CELL(my_ecto_module, my_ecto_module::Hello,"Hello", "Prints a string input to standard output.");
   
 
-Note that namespacing your implementations is a good idea to avoid linktime ODR
+Note that namespacing your implementations is a good idea to avoid linktime One Definition Rule (ODR)
 violations.  Also notice that most ecto modules do not contain header files, as your
 ecto cells should be rather self contained, use common types for 
 tendrils (int, float, cv::Mat, pcl::PointCloud), etc ...

--- a/doc/source/usage/tutorials/tendrils_spore.rst
+++ b/doc/source/usage/tutorials/tendrils_spore.rst
@@ -6,10 +6,7 @@ They are a mapping from a string to the matching :ref:`tendril <tendril-overview
 tendril then ? Well, it is a container that holdes the input/output/parameter in a type-agnostic
 way (like a ``boost::any``) to allow for static introspection and Python interaction.
 
-We have seen some code that uses tendrils to extract the information at runtime but there are other ways
-of getting the data. We will here show three ways. You will most likely always use the last one as it is
-the most convenient to write but the other ones can also have their use case (usually for lower level
-tendril manipulation)
+We have seen some code that uses tendrils to extract the information at runtime but there are other ways of getting the data. Here we will show three different ways to get the data, but you will most likely always use the last one. The first method is the most convenient to write but the other methods can also have their use case (usually for lower level tendril manipulation).
 
 We have seen how to use tendrils with a runtime registration:
 


### PR DESCRIPTION
overview/cells: one spelling, one grammatical
overview/modules: clarification of acronym
usage/tutorials/tendrils_spore: rewording
