### PR TITLE
Added depend on python

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,8 +9,10 @@
 
   <url>http://ecto.willowgarage.com</url>
   <build_depend>boost</build_depend>
+  <build_depend>python</build_depend>
 
   <run_depend>boost</run_depend>
+  <run_depend>python</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 </package>


### PR DESCRIPTION
The python development libraries are needed at https://github.com/plasmodic/ecto/blob/master/CMakeLists.txt#L37, so we need to depend on python.
