### PR TITLE
Posix signal handling

### DIFF
--- a/include/ecto/scheduler.hpp
+++ b/include/ecto/scheduler.hpp
@@ -33,6 +33,10 @@
 #include <ecto/profile.hpp>
 
 #include <boost/asio.hpp>
+#ifndef BOOST_SIGNALS2_MAX_ARGS  // this is also defined in tendril.hpp (TODO: consolidate)
+  #define BOOST_SIGNALS2_MAX_ARGS 3
+#endif
+#include <boost/signals2/signal.hpp>
 #include <boost/thread/mutex.hpp>
 
 #include <ecto/impl/graph_types.hpp>
@@ -155,6 +159,9 @@ private:
   State state_;
   //! Current number of "runners" (threads calling a run method).
   std::size_t runners_;
+
+  // sigint handling
+  boost::signals2::connection interrupt_connection;
   bool interrupted;
 }; // scheduler
 

--- a/include/ecto/tendril.hpp
+++ b/include/ecto/tendril.hpp
@@ -29,7 +29,9 @@
 #pragma once
 #include <boost/shared_ptr.hpp>
 #include <boost/function/function1.hpp>
-#define BOOST_SIGNALS2_MAX_ARGS 3
+#ifndef BOOST_SIGNALS2_MAX_ARGS
+  #define BOOST_SIGNALS2_MAX_ARGS 3
+#endif
 #include <boost/signals2.hpp>
 #include <boost/any.hpp>
 


### PR DESCRIPTION
**Problem**

Commit dd8fef0ec00cbb9e489aa9156206e4f0508ac12c introduce a big change in the scheduler - multithreading was dropped and async support modified. In the process, signal handling got [disconnected](https://github.com/plasmodic/ecto/commit/dd8fef0ec00cbb9e489aa9156206e4f0508ac12c#diff-8102ff9c980072a684d1f6fbc7b01e57R185) (note the `#if 0`).

This means that the python ectoscript controlling this c++ execution would only receive a notification of the signal via [PyErr_SetInterrupt()](https://github.com/plasmodic/ecto/blob/master/src/lib/scheduler.cpp#L61) only after any c++ execution terminated.

In the case of an `execute()` call, or `execute(niter=_some_large_number)`. This can be a very long time.

**Solutions**

You can force the python ecto script to check for signals with `PyErr_CheckSignals()`, see [Ethan's comment](https://github.com/plasmodic/ecto/blob/master/src/lib/scheduler.cpp#L65) but this may be a bad way of doing it. Perhaps it clobbers the underlying c++ execution? Better would be to get the c++ execution to terminate gracefully.

All I've done here is set a flag that replicates the `ecto::QUIT` behaviour. Another way would be to trigger it via `stop()` but I'm unclear on who or what calls that yet. It has issues trying that with the current code as well.

Thoughts?
