### PR TITLE
Remove usage of SYSTEM in include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ git_status(ecto)
 include_directories(include)
 include_directories(src/lib)
 include_directories(${CATKIN_DEVEL_PREFIX}/include)
-include_directories(SYSTEM
+include_directories(
   ${PYTHON_INCLUDE_PATH}
   ${Boost_INCLUDE_DIRS}
 )

--- a/cmake/ectoMacros.cmake
+++ b/cmake/ectoMacros.cmake
@@ -65,9 +65,9 @@ macro(ectomodule NAME)
       )
   endif()
   #these are required includes for every ecto module
-  include_directories(SYSTEM ${ecto_INCLUDE_DIRS}
-                             ${PYTHON_INCLUDE_PATH}
-                             ${Boost_INCLUDE_DIRS}
+  include_directories(${ecto_INCLUDE_DIRS}
+                      ${PYTHON_INCLUDE_PATH}
+                      ${Boost_INCLUDE_DIRS}
   )
 
   add_library(${NAME}_ectomodule SHARED

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -31,9 +31,9 @@ if(NOT CATKIN_ENABLE_TESTING)
   return()
 endif()
 
-include_directories(SYSTEM ${GTEST_INCLUDE_DIRS}
-                           ${PYTHON_INCLUDE_PATH}
-                           ${Boost_INCLUDE_DIRS}
+include_directories(${GTEST_INCLUDE_DIRS}
+                    ${PYTHON_INCLUDE_PATH}
+                    ${Boost_INCLUDE_DIRS}
 )
 
 catkin_add_gtest(ecto-test


### PR DESCRIPTION
SYSTEM should be used sparingly and causes some things to go awry in ros workspaces.

See dirk's comments at the end of https://github.com/ros/catkin/issues/428.
