### PR TITLE
Proper depends syntax for pythonlibs find-packages variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ find_package(PythonLibs REQUIRED)
 
 
 catkin_package(CFG_EXTRAS ecto-extras.cmake
-               DEPENDS Boost PythonLibs Threads
+               DEPENDS Boost PYTHON Threads
                INCLUDE_DIRS include
                LIBRARIES ecto
 )


### PR DESCRIPTION
The FindPythonLibs.cmake module doesn't set `PythonLibs_INCLUDE_DIRS/LIBRARIES`. Instead it sets `PYTHON_INCLUDE_DIRS` and `PYTHON_LIBRARIES`. Since catkin package's `DEPENDS` variable requires the exact syntax, this should change from `PythonLibs` -> `Python`.
