### PR TITLE
Bugfix pythonic cell construction

### DIFF
--- a/python/ecto/cell.py
+++ b/python/ecto/cell.py
@@ -31,7 +31,7 @@ class Cell(_cell_base):
     """
     When creating a cell from Python, just inherit from that class and define
     the same functions as in C++ if you want (i.e. declare_params(self, p),
-    declare_io(self, p), configure(self, p, i, o) and run(self, i, o)
+    declare_io(self, p, i, o), configure(self, p, i, o) and process(self, i, o)
     """
     __looks_like_a_cell__ = True
     def __getattr__(self, name):
@@ -44,10 +44,9 @@ class Cell(_cell_base):
                 raise AttributeError(self, name)
 
     def __init__(self, *args, **kwargs):
+        _cell_base.__init__(self)
         if args:
-            _cell_base.__init__(self, args[0])
-        else:
-            _cell_base.__init__(self)
+            _cell_base.name(self, args[0])
 
         _cell_base.declare_params(self)
 
@@ -55,7 +54,6 @@ class Cell(_cell_base):
             self.params.at(k).set(v)
         self.params.notify()
         _cell_base.declare_io(self)
-        _cell_base.configure(self)
         if self.__doc__ is None:
             self.__doc__ = "TODO docstr me."
         self._short_doc = self.__doc__

--- a/src/pybindings/cell.cpp
+++ b/src/pybindings/cell.cpp
@@ -86,7 +86,7 @@ namespace ecto
       {
         ECTO_SCOPED_CALLPYTHON();
         if (bp::override config = this->get_override("configure"))
-          config(boost::ref(params));
+          config(boost::ref(params), boost::ref(inputs), boost::ref(outputs));
       }
 
       void dispatch_activate()

--- a/test/scripts/pyecto/MyModule.py
+++ b/test/scripts/pyecto/MyModule.py
@@ -30,7 +30,7 @@ import ecto
 class MyModule(ecto.Cell):
     """ A python module that does not much."""
     def __init__(self, *args, **kwargs):
-        ecto.Cell.__init__(self, **kwargs)
+        ecto.Cell.__init__(self, *args, **kwargs)
     
     @staticmethod
     def declare_params(params):
@@ -41,7 +41,7 @@ class MyModule(ecto.Cell):
         inputs.declare("input","aye", 2)
         outputs.declare("out", "i'll give you this", "hello")
     
-    def configure(self,params):
+    def configure(self,params, inputs, outputs):
         print "configure!"
         self.text = params.text
 

--- a/test/scripts/test_python_module.py
+++ b/test/scripts/test_python_module.py
@@ -33,7 +33,8 @@ import time
 
 
 def test_python_module():
-    mod = MyModule(text="spam")
+    mod = MyModule("mymodule", text="spam")
+    mod.configure(mod.params, mod.inputs, mod.outputs)
     assert mod.text == "spam"
     assert mod.params.text == "spam"
     mod.process(mod.inputs,mod.outputs)
@@ -44,6 +45,7 @@ def test_python_module_plasm(Schedtype):
     print "*"*80
     print Schedtype
     mod = MyModule(text="spam")
+    mod.configure(mod.params, mod.inputs, mod.outputs)
     g = ecto_test.Generate(start = 1 , step =1)
     plasm = ecto.Plasm()
     plasm.connect(g,"out",mod,"input")


### PR DESCRIPTION
This does the following:
- Allows a cell name override to be passed in **args (just like c++)

This was conspicuously causing an error if you tried - the c++ api for cell construction didn't take an arg. I noticed the python test was dodging this bullet by not passing along `*args` at all. I couldn't work out how to get this to work with the c++ constructor call, but managed to work around by delaying name setting till after the `__init__`. 
- Removes the configure step from construction

This syncs it with c++ behaviour and opens up the possibility of getting it working with directed configuration (#260).
- Adds input and output tendrils to the configure step to sync with c++ api
- Bugfixes `self.__dict__.hasget` (pretty sure dict has no `hasget` method ;))

While messing around I had this getting thrown, but I think it was just hiding because it doesn't get accessed so often. Certainly not in the tests.
- Updated the python module test and made sure it is testing for naming as well.
