### PR TITLE
Bugfix python lookup for internal class variables

### DIFF
--- a/python/ecto/cell.py
+++ b/python/ecto/cell.py
@@ -38,7 +38,7 @@ class Cell(_cell_base):
         if name == '__impl':
             return self
         else:
-            if self.__dict__.hasget(name, None):
+            if name in self.__dict__:
                 return self.__dict__[name]
             else:
                 raise AttributeError(self, name)


### PR DESCRIPTION
`__dict__.hasget()` is entirely fictional. Probably went unnoticed for a long time since it wasn't called by anyone.

Came across this (I think - was quite a while ago) while fleshing out pythonic cell construction with names and parameter args. Should have gone in at the same time as 39b9cad9.