### PR TITLE
Don't clobber the underlying c++ executions when aborting, be graceful.

### DIFF
--- a/src/lib/scheduler.cpp
+++ b/src/lib/scheduler.cpp
@@ -58,7 +58,6 @@ namespace {
               << "*** when back in the interpreter thread.\n"
               << "*** or Ctrl-\\ (backslash) for a hard stop.\n" << std::endl;
     SINGLE_THREADED_SIGINT_SIGNAL();
-    PyErr_SetInterrupt();
   }
 } // End of anonymous namespace.
 


### PR DESCRIPTION
Previously used PyErr_SetInterrupt which would send a keyboard interrupt
back to the controlling python script. However we don't want to abort
in this way - it is preferable to let the execution gracefully bow out.
More information and the actual code that does the bowing out is in
pull request #250.