### PR TITLE
Docs about various entities that affect graph execution

### DIFF
--- a/doc/kitchen/index.rst
+++ b/doc/kitchen/index.rst
@@ -5,7 +5,7 @@ Initially aimed at computer vision and perception research tasks, Ecto is a hybr
 
 Ecto itself is small, has minimal dependencies (C++, Boost, Python) and works with or without OpenCV, PCL, and ROS in any combination. We believe that Ecto allows vision and perception researchers to express their computational models in a natural fashion, obviating e.g. ROS time synchronizers and ROS nodelets in most cases.
 
-As of 2012, Ecto is officially released. It is being used by researchers at Willow Garage and in industry for prototype applications of object capture and modelling, `object recognition <http://wg-perception.github.com/object_recognition_core/>`_, pose estimation and refinement, projector-based augmented reality and chess playing.
+As of 2012, Ecto is officially released. It is being used by researchers at Willow Garage and in industry for prototype applications of object capture and modelling, `object recognition <http://wg-perception.github.com/object_recognition_core/>`_, pose estimation and refinement, vision slam, projector-based augmented reality and chess playing.
 
 
 To understand ecto, you probably want to go over the Ecto docs first:
@@ -13,8 +13,8 @@ To understand ecto, you probably want to go over the Ecto docs first:
 .. toctree::
    :maxdepth: 1
 
-   ecto/overview/index.rst
-   Advanced Install <ecto/install/index.rst>
+   Overview <ecto/overview/index.rst>
+   Install <ecto/install/index.rst>
    Usage <ecto/usage/index.rst>
    ecto/reference/index.rst
 
@@ -27,39 +27,6 @@ Ecto has several modules that wrap different libraries or functionalities:
    * :ref:`ecto_openni <ectoopenni:ecto_openni>`
    * :ref:`ecto_pcl <ectopcl:ecto_pcl>`
    * :ref:`ecto_ros <ectoros:ecto_ros>`
-
-.. rubric:: Install
-
-If you are on ROS Fuerte or above, you probably just want to install the packages available in the ROS repositories named ros-DISTO-ecto-PACKAGE
-
-If you want to install from source, you will have to get them from https://github.com/plasmodic/ecto:
-
-.. code-block:: bash
-
-  mkdir ecto_kitchen && cd ecto_kitchen
-  sudo pip install catkin_pkg breathe empy
-  git clone http://github.com/ros/catkin.git
-  git clone http://github.com/plasmodic/ecto.git
-  ln -s catkin/cmake/toplevel.cmake CMakeLists.txt
-
-Then get the ecto modules you want (and make sure their dependencies defined in their package.xml
-are on your path):
-
-.. code-block:: bash
-
-  git clone http://github.com/plasmodic/ecto_image_pipeline.git
-  git clone http://github.com/plasmodic/ecto_openni.git
-  git clone http://github.com/wg-perception/opencv_candidate.git
-  git clone http://github.com/plasmodic/ecto_opencv.git
-  git clone http://github.com/plasmodic/ecto_pcl.git
-  git clone http://github.com/plasmodic/ecto_ros.git
-
-And you're then good to go for the usual cmake install except you need to add ``catkin_pkg``
-to your Python path:
-
-.. code-block:: bash
-
-  mkdir build && cd build && cmake ../ && make
 
 .. rubric:: Bug reports
 

--- a/doc/source/install/get_ecto.rst
+++ b/doc/source/install/get_ecto.rst
@@ -1,6 +1,20 @@
 Build Ecto From Source
 ======================
 
+Dependencies
+----------------------------------------
+
+On ubuntu its simple....
+
+.. code-block:: sh
+
+    sudo apt-get install libboost-python-dev libboost-filesystem-dev libboost-system-dev \
+            libboost-thread-dev python-setuptools python-gobject python-gtk2 graphviz doxygen \
+            python-sphinx
+
+Downloading
+----------------------------------------
+
 ecto is available here: https://github.com/plasmodic/ecto
 
 It is also dependent on ``catkin``
@@ -25,7 +39,20 @@ You should see the following outputish:
     Resolving deltas: 100% (3226/3226), done.
 
 
-building ecto
+Then get the ecto modules you want (and make sure their system dependencies
+defined in their package.xml are already installed and on your path):
+
+.. code-block:: bash
+
+  git clone http://github.com/plasmodic/ecto_image_pipeline.git
+  git clone http://github.com/plasmodic/ecto_openni.git
+  git clone http://github.com/wg-perception/opencv_candidate.git
+  git clone http://github.com/plasmodic/ecto_opencv.git
+  git clone http://github.com/plasmodic/ecto_pcl.git
+  git clone http://github.com/plasmodic/ecto_ros.git
+
+
+Building
 -------------
 
 Using a standard cmake build system, you must first create a build directory and
@@ -110,17 +137,6 @@ You should see the following outputish:
     q
     q
 
-Dependencies
-----------------------------------------
-
-On ubuntu its simple....
-
-.. code-block:: sh
-
-    sudo apt-get install libboost-python-dev libboost-filesystem-dev libboost-system-dev \
-            libboost-thread-dev python-setuptools python-gobject python-gtk2 graphviz doxygen \
-            python-sphinx
-
 Install
 ---------------------------------------
 
@@ -153,11 +169,9 @@ Docs may be generated from the source in the following manner.
 .. code-block:: sh
 
 	cd build
-	make doc #for all documentaition
-	make html #for sphinx (prefer this for usage docs)
-	make pdf #sphinx pdf manual
-	make doxygen #for c++ api docs
-	ccmake . #edit doc options.
+	make sphinx-doc # for sphinx (prefer this for usage docs)
+	make doxygen    # for c++ api docs
+	ccmake .        # edit doc options.
 
 Tests
 --------------------------------------------------

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -3,20 +3,25 @@
 Installing ecto
 ===============
 
-If you have access to a ROS repository, just install the ros-ditro_name-ecto packages. E.g., if you are on Groovy:
+If you have access to a ROS repository, just install the ros-distro_name-ecto packages. E.g., if you are on Indigo:
 
 .. code-block:: bash
 
-    sudo apt-get install ros-groovy-ecto
-
+    sudo apt-get install ros-indigo-ecto
 
 Otherwise, ecto is still easy to build from source:
 
 .. toctree::
     :maxdepth: 1
 
-    dependencies.rst    
     get_ecto.rst
+
+To install with a cantankerous boost of your own choosing:
+
+.. toctree::
+    :maxdepth: 1
+
+    non_system_boost.rst
 
 Windows support is still experimental but we had good experience with ``cygwin``:
 

--- a/doc/source/install/non_system_boost.rst
+++ b/doc/source/install/non_system_boost.rst
@@ -1,19 +1,5 @@
-Dependencies
-============
-
-Packages
---------
-
-Ecto only depends on Python and Boost so make sure you have those two sets of tools.
-On Ubuntu, simply install the corresponding pacakges:
-
-.. code-block:: bash
-
-   sudo pip install catkin_pkg breathe empy
-   sudo apt-get install python libboost-dev
-
 Nonsystem Boost
----------------
+===============
 
 (Accurate as of boost 1.47.0)
 

--- a/doc/source/usage/tutorials/plasms.rst
+++ b/doc/source/usage/tutorials/plasms.rst
@@ -86,7 +86,7 @@ see :ref:`entanglement` for more information.
 Execution
 ^^^^^^^^^
 
-Once a plasm is constructed, it may be used with an :ref:`ecto scheduler <schedulers>`
+Once a plasm is constructed, it may be used with an :ref:`ecto scheduler <schedulers>`.
 
 .. literalinclude:: srcs/plasms.py
   :language: py
@@ -99,4 +99,32 @@ does a `topological-sort`_
 on the graph, and then executes each cell in order.
 This repeats for the specified number of iterations,
 or indefinitely if ``niter`` is ``0``.
+
+For parallel or threaded execution of plasms, please read the :ref:`schedulers <schedulers>`
+documentation for a more detailed reference. Note that support for parallel execution is
+presently restricted to running multiple graphs in parallel. Although one of the project's
+initial design goals, it does not at this time introduce parallelism to the internal execution
+of a graph (this is a very complex thing to manage).
+
+Affecting the Execution of the Graph
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are various tricks that can be used to affect/interrupt/halt the direction of execution
+of the graph.
+
+Various cells can manipulate the graph by grouping or providing some conditional logic that
+affects the processing of cells that have been combined internally within themselves.
+See for example, the :ref:`black_box` and :ref:`If <if>` cells.
+
+The return value from a cell's `process()` function will also instruct the :ref:`scheduler <schedulers>`
+on how it should continue processing cells in the remainder of the graph. The possible return values
+are listed below with an explanation for quick reference:
+
+* :ref:`ecto::OK` : directed execution proceeds normally to the next cell in the graph.
+* :ref:`ecto::DO_OVER` : repeats processing for that cell.
+* :ref:`ecto::BREAK` : abort the current iteration of the graph and return to its starting point.
+* :ref:`ecto::QUIT` : completely terminate the execution.
+
+Mutexes/barriers or similar intraprocess mechanisms inside a cell that is present in
+multiple parallelised graphs will also halt execution of the graph at a particular point.
 


### PR DESCRIPTION
As introduced by the new `ecto::BREAK` discussed in #279.

Also removed the redundancies in the install docs (2x install instructions and 2x dependencies)
and cleaned the place up a bit.