### PR TITLE
Re-add thread library to linker list

### DIFF
--- a/doc/source/usage/advanced/CMakeLists.txt
+++ b/doc/source/usage/advanced/CMakeLists.txt
@@ -33,4 +33,5 @@ target_link_libraries(tutorial_native_plasm
   ecto
   ${catkin_LIBRARIES}
   hello_ecto_ectomodule #uses cells from this module.
+  ${CMAKE_THREAD_LIBS_INIT}
 )

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(ecto
   ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}
   ${PYTHON_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
 )
 
 set_source_files_properties(log.cpp

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(ecto-test
   ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}
   ${PYTHON_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
 )
 
 # This is actually used in the plasm loader Python test file
@@ -67,4 +68,5 @@ target_link_libraries(plasm_loader
   ecto
   ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
 )


### PR DESCRIPTION
Regression caused by 8e354b5aa8281ea8117fc93adb290998b7810be7

Seems to only affect ARM for whatever reason.

Presents with:
```
/usr/bin/ld: CMakeFiles/plasm_loader.dir/plasm_loader.cpp.o: undefined reference to symbol 'pthread_key_delete@@GLIBC_2.4'
/usr/lib/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

Example build break: https://csc.mcs.sdsmt.edu/jenkins/job/ros-jade-ecto_binaryrpm_22_armhfp/8/console

Thanks,

--scott