### PR TITLE
checking for ecto-test target existence

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -26,7 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-if(NOT CATKIN_ENABLE_TESTING)
+if(NOT CATKIN_ENABLE_TESTING OR NOT TARGET ecto-test)
   message(STATUS "Disabling testing since gtest was not found.")
   return()
 endif()


### PR DESCRIPTION
Only checking at CATKIN_ENABLE_TESTING is not enough to build cmake tree if we don't have gtest on system.

Plus, before needed to install:

    sudo pip install catkin_pkg