### PR TITLE
Install the test cell library

### DIFF
--- a/test/cells/CMakeLists.txt
+++ b/test/cells/CMakeLists.txt
@@ -62,4 +62,5 @@ ectomodule(ecto_test
   gil_exercise.cpp
   ecto_test.cpp
   DESTINATION  ecto
+  INSTALL
 )


### PR DESCRIPTION
I've been unwittingly using these from devel space underlays, but would like to access them from install spaces as they provide alot of useful cells to build some of our own tests from.