### PR TITLE
fix cmake in tutorial doc.

### DIFF
--- a/doc/source/usage/tutorials/hello.rst
+++ b/doc/source/usage/tutorials/hello.rst
@@ -18,7 +18,7 @@ You'll need a CMake file named ``CMakeLists.txt`` :download:`srcs/CMakeListsHell
 c++
 ---
 
-So, the c++ side of things.  Ecto code structurally break down into 
+So, the c++ side of things.  Ecto code structurally break down into
 :ref:`Cells <cells-overview>` and :ref:`Modules <modules-overview>`
 
 The module code:
@@ -26,16 +26,16 @@ The module code:
   Download: :download:`srcs/tutorial.cpp`
 
   .. _code-module:
- 
+
   .. literalinclude:: srcs/tutorial.cpp
      :language: cpp
-  
+
 The cell code:
 
   Download: :download:`srcs/Hello.cpp`
 
   .. _code-hello:
-  
+
   .. literalinclude:: srcs/Hello.cpp
     :language: cpp
 

--- a/doc/source/usage/tutorials/srcs/CMakeListsHello.txt
+++ b/doc/source/usage/tutorials/srcs/CMakeListsHello.txt
@@ -8,7 +8,10 @@ find_package(ecto REQUIRED)
 # This is all you need to know: it will create an ecto module named tutorial
 # and it will be built in the ${where_your_Python_lib_are_bult}/ecto_tutorial folder.
 # If you add the ``INSTALL`` flag, it will also install it when you do ``make install`
-ectomodule(tutorial DESTINATION ./ecto_tutorial INSTALL
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/ecto_tutorial)
+
+ectomodule(tutorial DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} INSTALL
     # You need a file defining the module (cf. below)
     tutorial.cpp
     # You need a file defining some content for module (cf. below)


### PR DESCRIPTION
To fix this error.
```
Scanning dependencies of target tutorial_ectomodule
[ 33%] Building CXX object CMakeFiles/tutorial_ectomodule.dir/tutorial.cpp.o
[ 66%] Building CXX object CMakeFiles/tutorial_ectomodule.dir/Hello.cpp.o
[100%] Linking CXX shared library //ecto_tutorial/tutorial.so
/usr/bin/ld: cannot open output file //ecto_tutorial/tutorial.so: No such file or directory
collect2: error: ld returned 1 exit status
CMakeFiles/tutorial_ectomodule.dir/build.make:131: recipe for target '//ecto_tutorial/tutorial.so' failed
make[2]: *** [//ecto_tutorial/tutorial.so] Error 1
CMakeFiles/Makefile2:99: recipe for target 'CMakeFiles/tutorial_ectomodule.dir/all' failed
make[1]: *** [CMakeFiles/tutorial_ectomodule.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```