### PR TITLE
fix runtime warning while python conversion

### DIFF
--- a/src/pybindings/cell.cpp
+++ b/src/pybindings/cell.cpp
@@ -42,6 +42,7 @@
 #include <string>
 namespace bp = boost::python;
 #include "tendril_spec.hpp"
+#include "converter.hpp"
 
 namespace ecto
 {
@@ -188,7 +189,7 @@ namespace ecto
         .def("activate", ((void(cell::*)()) &cell::activate))
         .def("deactivate", ((void(cell::*)()) &cell::deactivate))
         ;
-      bp::register_ptr_to_python<boost::shared_ptr<cell> >();
+      BP_REGISTER_SHARED_PTR_TO_PYTHON(cell);
 
       bp::class_<cellwrap, boost::shared_ptr<cellwrap>, boost::noncopyable> ("_cell_base" /*bp::no_init*/)
         .def("_set_process_connected_inputs_only", &cell::set_process_connected_inputs_only)
@@ -222,7 +223,7 @@ namespace ecto
         .def("__getitem__", getitem_list)
         .def("__getitem__", getitem_slice)
         ;
-      bp::register_ptr_to_python<boost::shared_ptr<cellwrap> >();
+      BP_REGISTER_SHARED_PTR_TO_PYTHON(cellwrap);
 
       bp::def("__getitem_str__", getitem_str);
       bp::def("__getitem_slice__", getitem_slice);

--- a/src/pybindings/converter.hpp
+++ b/src/pybindings/converter.hpp
@@ -1,0 +1,21 @@
+
+#ifndef __BP_REGISTER_SHARED_PTR_CONVERTER_HPP__
+#define __BP_REGISTER_SHARED_PTR_CONVERTER_HPP__
+#include <boost/python/register_ptr_to_python.hpp>
+
+namespace bp = boost::python;
+
+/* Fix to avoid registration warnings in pycaffe (#3960) */
+#define BP_REGISTER_SHARED_PTR_TO_PYTHON(PTR) do { \
+  const boost::python::type_info info = \
+    boost::python::type_id<boost::shared_ptr<PTR > >(); \
+  const boost::python::converter::registration* reg = \
+    boost::python::converter::registry::query(info); \
+  if (reg == NULL) { \
+    bp::register_ptr_to_python<boost::shared_ptr<PTR > >(); \
+  } else if ((*reg).m_to_python == NULL) { \
+    bp::register_ptr_to_python<boost::shared_ptr<PTR > >(); \
+  } \
+} while (0)
+
+#endif

--- a/src/pybindings/tendril.cpp
+++ b/src/pybindings/tendril.cpp
@@ -34,6 +34,8 @@
 
 #include <ecto/serialization/tendril.hpp>
 
+#include "converter.hpp"
+
 namespace bp = boost::python;
 
 namespace ecto
@@ -169,7 +171,7 @@ void wrapConnection(){
     Tendril_.def("listT", &py_tendril_reg_list);
     Tendril_.staticmethod("listT");
     Tendril_.enable_pickling();
-  bp::register_ptr_to_python< boost::shared_ptr<tendril> >();
+  BP_REGISTER_SHARED_PTR_TO_PYTHON(tendril);
 
 }
 }


### PR DESCRIPTION
Fixing python conversion warning using register_ptr_to_python
```
/home/jihoonl/research/ros/ecto/devel/lib/python2.7/dist-packages/ecto/__init__.py:30: RuntimeWarning: to-Python converter for boost::shared_ptr<ecto::tendril> already registered; second conversion method ignored.
  del os_path
/home/jihoonl/research/ros/ecto/devel/lib/python2.7/dist-packages/ecto/__init__.py:30: RuntimeWarning: to-Python converter for boost::shared_ptr<ecto::cell> already registered; second conversion method ignored.
  del os_path
/home/jihoonl/research/ros/ecto/devel/lib/python2.7/dist-packages/ecto/__init__.py:30: RuntimeWarning: to-Python converter for boost::shared_ptr<ecto::py::cellwrap> already registered; second conversion method ignored.
```

As proposed in https://github.com/BVLC/caffe/pull/4069

