### PR TITLE
Update rosdep key

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
 
   <run_depend>boost</run_depend>
   <run_depend>python</run_depend>
-  <run_depend>xdot</run_depend>
+  <run_depend>python-xdot</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 </package>


### PR DESCRIPTION
As warned in https://github.com/plasmodic/ecto/issues/297 the rosdep key xdot is now python-xdot

Further discussion can be found at: https://github.com/ros/rosdistro/pull/17553#pullrequestreview-114509432